### PR TITLE
[Video Player] Changed to send completed event message from main thread

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.2
+* Changed to send stream completed messages from main thread.
+
 ## 0.9.1
 * Temporarily disable auto-repeat.
 * Update the elinux template of the example app.

--- a/packages/video_player/elinux/gst_video_player.h
+++ b/packages/video_player/elinux/gst_video_player.h
@@ -65,6 +65,7 @@ class GstVideoPlayer {
   double playback_rate_ = 1.0;
   bool mute_ = false;
   bool auto_repeat_ = false;
+  bool is_completed_ = false;
   std::shared_mutex mutex_buffer_;
   std::unique_ptr<VideoPlayerStreamHandler> stream_handler_;
 };

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_player_elinux
 description: Flutter plugin for displaying inline video with other Flutter widgets on Embedded Linux.
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/sony/flutter-elinux-plugins
 repository: https://github.com/sony/flutter-elinux-plugins/tree/main/packages/video_player/video_player
 


### PR DESCRIPTION
I changed to send the completed event messages from main thread to avoid flutter engine's fml checker error.