### PR TITLE
[video_player] update dependencies plugin version

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4
+* Upgrade video_player_platform_interface from 4.1.0 to 4.2.0.
+* Refactor example source code.
+
 ## 0.9.3
 * Improve the error handling.
 * Add the missing mutex.

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -33,7 +33,7 @@ class _App extends StatelessWidget {
             tabs: <Widget>[
               Tab(
                 icon: Icon(Icons.cloud),
-                text: "Remote",
+                text: 'Remote',
               ),
             ],
           ),
@@ -109,7 +109,7 @@ class _ControlsOverlay extends StatelessWidget {
   const _ControlsOverlay({Key? key, required this.controller})
       : super(key: key);
 
-  static const _examplePlaybackRates = [
+  static const List<double> _examplePlaybackRates = [
     0.25,
     0.5,
     1.0,
@@ -127,13 +127,13 @@ class _ControlsOverlay extends StatelessWidget {
     return Stack(
       children: <Widget>[
         AnimatedSwitcher(
-          duration: Duration(milliseconds: 50),
-          reverseDuration: Duration(milliseconds: 200),
+          duration: const Duration(milliseconds: 50),
+          reverseDuration: const Duration(milliseconds: 200),
           child: controller.value.isPlaying
-              ? SizedBox.shrink()
+              ? const SizedBox.shrink()
               : Container(
                   color: Colors.black26,
-                  child: Center(
+                  child: const Center(
                     child: Icon(
                       Icons.play_arrow,
                       color: Colors.white,
@@ -157,7 +157,7 @@ class _ControlsOverlay extends StatelessWidget {
             },
             itemBuilder: (context) {
               return [
-                for (final speed in _examplePlaybackRates)
+                for (final double speed in _examplePlaybackRates)
                   PopupMenuItem(
                     value: speed,
                     child: Text('${speed}x'),

--- a/packages/video_player/example/pubspec.yaml
+++ b/packages/video_player/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the video_player plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  video_player: ^2.1.12
+  video_player: ^2.2.5
   video_player_elinux:
     path: ../
 

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_player_elinux
 description: Flutter plugin for displaying inline video with other Flutter widgets on Embedded Linux.
-version: 0.9.3
+version: 0.9.4
 homepage: https://github.com/sony/flutter-elinux-plugins
 repository: https://github.com/sony/flutter-elinux-plugins/tree/main/packages/video_player
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^4.1.0
+  video_player_platform_interface: ^4.2.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Updates
- Upgrade `video_player_platform_interface` from 4.1.0 to 4.2.0
- Update example
  - `video_player` from 2.1.12 to 2.2.5
  - Refactor source file