### PR TITLE
[video_player] Add support GstEGLImage to improve playback performance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 
 Sony Group Corporation
 Hidenori Matsubayashi (hidenori.matsubayashi@gmail.com)
+Makoto Sato (makoto.sato@atmark-techno.com)

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.7
+* Improve playback performance if GstEGLImage is avalable.
+
 ## 0.9.6
 * Update for video_player_platform_interface v5.1.1 / video_player v2.4.7 / flutter 3.3.0
 

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -44,3 +44,10 @@ playbin uri=<file> video-sink="videoconvert ! video/x-raw,format=RGBA ! fakesink
 
 #### e.g. customization for i.MX 8M platforms:
 playbin uri=<file> video-sink="imxvideoconvert_g2d ! video/x-raw,format=RGBA ! fakesink"
+
+### Enable GstEGLImage
+If GstEGLImage is enabled on your target device, adding the following code to `<user's project>/elinux/CMakeLists.txt` may improve playback performance.
+```
+add_definitions(-DUSE_EGL_IMAGE_DMABUF)
+set(USE_EGL_IMAGE_DMABUF "on")
+```

--- a/packages/video_player/elinux/CMakeLists.txt
+++ b/packages/video_player/elinux/CMakeLists.txt
@@ -9,6 +9,9 @@ set(PLUGIN_NAME "video_player_elinux_plugin")
 find_package(PkgConfig)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
+if(USE_EGL_IMAGE_DMABUF)
+pkg_check_modules(GSTREAMER_GL REQUIRED gstreamer-gl-1.0)
+endif()
 
 add_library(${PLUGIN_NAME} SHARED
   "video_player_elinux_plugin.cc"
@@ -27,12 +30,24 @@ target_include_directories(${PLUGIN_NAME}
     ${GLIB_INCLUDE_DIRS}
     ${GSTREAMER_INCLUDE_DIRS}
 )
+if(USE_EGL_IMAGE_DMABUF)
+target_include_directories(${PLUGIN_NAME}
+  PRIVATE
+    ${GSTREAMER_GL_INCLUDE_DIRS}
+)
+endif()
 
 target_link_libraries(${PLUGIN_NAME}
   PRIVATE
     ${GLIB_LIBRARIES}
     ${GSTREAMER_LIBRARIES}
 )
+if(USE_EGL_IMAGE_DMABUF)
+target_link_libraries(${PLUGIN_NAME}
+  PRIVATE
+    ${GSTREAMER_GL_LIBRARIES}
+)
+endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(video_player_elinux_bundled_libraries

--- a/packages/video_player/elinux/gst_video_player.h
+++ b/packages/video_player/elinux/gst_video_player.h
@@ -7,6 +7,13 @@
 
 #include <gst/gst.h>
 
+#ifdef USE_EGL_IMAGE_DMABUF
+#include <gst/allocators/gstdmabuf.h>
+#include <gst/gl/egl/egl.h>
+#include <gst/gl/gl.h>
+#include <gst/video/video.h>
+#endif  // USE_EGL_IMAGE_DMABUF
+
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -33,6 +40,9 @@ class GstVideoPlayer {
   int64_t GetDuration();
   int64_t GetCurrentPosition();
   const uint8_t* GetFrameBuffer();
+#ifdef USE_EGL_IMAGE_DMABUF
+  void* GetEGLImage(void* egl_display, void* egl_context);
+#endif  // USE_EGL_IMAGE_DMABUF
   int32_t GetWidth() const { return width_; };
   int32_t GetHeight() const { return height_; };
 
@@ -56,6 +66,9 @@ class GstVideoPlayer {
   void DestroyPipeline();
   void Preroll();
   void GetVideoSize(int32_t& width, int32_t& height);
+#ifdef USE_EGL_IMAGE_DMABUF
+  void UnrefEGLImage();
+#endif  // USE_EGL_IMAGE_DMABUF
 
   GstVideoElements gst_;
   std::string uri_;
@@ -70,6 +83,13 @@ class GstVideoPlayer {
   std::mutex mutex_event_completed_;
   std::shared_mutex mutex_buffer_;
   std::unique_ptr<VideoPlayerStreamHandler> stream_handler_;
+
+#ifdef USE_EGL_IMAGE_DMABUF
+  GstVideoInfo gst_video_info_;
+  GstEGLImage* gst_egl_image_ = NULL;
+  GstGLContext* gst_gl_ctx_ = NULL;
+  GstGLDisplayEGL* gst_gl_display_egl_ = NULL;
+#endif  // USE_EGL_IMAGE_DMABUF
 };
 
 #endif  // PACKAGES_VIDEO_PLAYER_VIDEO_PLAYER_ELINUX_GST_VIDEO_PLAYER_H_

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_player_elinux
 description: Flutter plugin for displaying inline video with other Flutter widgets on Embedded Linux.
-version: 0.9.6
+version: 0.9.7
 homepage: https://github.com/sony/flutter-elinux-plugins
 repository: https://github.com/sony/flutter-elinux-plugins/tree/main/packages/video_player
 


### PR DESCRIPTION
Hello.

I added `GstEGLImage` support to improve video_player playback performance.
If gst_is_`dmabuf_memory()` is `TRUE`, `GstEGLImage` can be used to improve performance without `gst_buffer_extract()`.
Relevant issue: #64

This requires the following PR:
sony/flutter-embedded-linux#327
and the option -DUSE_EGL_IMAGE_DMABUF is required at build time.