### PR TITLE
[video_player] fix type mismatch

### DIFF
--- a/packages/video_player/elinux/gst_video_player.cc
+++ b/packages/video_player/elinux/gst_video_player.cc
@@ -131,7 +131,7 @@ bool GstVideoPlayer::SetSeek(int64_t position) {
 
 int64_t GstVideoPlayer::GetDuration() {
   GstFormat fmt = GST_FORMAT_TIME;
-  int64_t duration_msec;
+  gint64 duration_msec;
   if (!gst_element_query_duration(gst_.pipeline, fmt, &duration_msec)) {
     std::cerr << "Failed to get duration" << std::endl;
     return -1;


### PR DESCRIPTION
The following error occurs when building:
```
gst_video_player.cc:135:8: error: no matching function for call to
'gst_element_query_duration'
  if (!gst_element_query_duration(gst_.pipeline, fmt, &duration_msec)) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gstreamer-1.0/gst/gstutils.h:1057:25: note: candidate function not viable:
no known conversion from 'int64_t *' (aka 'long long *') to 'gint64 *' (aka 'long *') for
3rd argument
gboolean                gst_element_query_duration      (GstElement *element, GstFormat
format, gint64 *duration);
                        ^
1 error generated.
```
So, I fix it.