### PR TITLE
video_player: fix the link to flutter/package in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The plugins for elinux are basically designed to be API compatible with the offi
 
 | Package for eLinux | Frontend package |
 | ------------------ | ---------------- |
-| [video_player_elinux](packages/video_player) | [video_player](https://github.com/flutter/plugins/tree/master/packages/video_player) |
+| [video_player_elinux](packages/video_player) | [video_player](https://github.com/flutter/packages/tree/main/packages/video_player/video_player) |
 | [camera_elinux](packages/camera) | [camera](https://github.com/flutter/packages/tree/main/packages/camera/camera) |
 | [path_provider_elinux](packages/path_provider) | [path_provider](https://github.com/flutter/packages/tree/main/packages/path_provider) |
 | [shared_preferences_elinux](packages/shared_preferences) | [shared_preferences](https://github.com/flutter/packages/tree/main/packages/shared_preferences) |

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -1,6 +1,6 @@
 # video_player_elinux
 
-The implementation of the Video Player plugin for flutter elinux. APIs are designed to be API compatible with the the official [`video_player`](https://github.com/flutter/plugins/tree/master/packages/video_player).
+The implementation of the Video Player plugin for flutter elinux. APIs are designed to be API compatible with the the official [`video_player`](https://github.com/flutter/packages/tree/main/packages/video_player/video_player).
 
 ![image](https://user-images.githubusercontent.com/62131389/124210378-43f06400-db26-11eb-8723-40dad0eb67b0.png)
 


### PR DESCRIPTION
This change fixes the old URL of flutter official plugin for video player.