### PR TITLE
[video_player/camera] fix the return value of GstVideoPlayer::HandleGstMessage()

### DIFF
--- a/packages/camera/elinux/gst_camera.cc
+++ b/packages/camera/elinux/gst_camera.cc
@@ -272,6 +272,7 @@ void GstCamera::HandoffHandler(GstElement* fakesink, GstBuffer* buf,
   int height;
   gst_structure_get_int(structure, "width", &width);
   gst_structure_get_int(structure, "height", &height);
+  gst_caps_unref(caps);
   if (width != self->width_ || height != self->height_) {
     self->width_ = width;
     self->height_ = height;

--- a/packages/camera/elinux/gst_camera.cc
+++ b/packages/camera/elinux/gst_camera.cc
@@ -155,7 +155,7 @@ bool GstCamera::CreatePipeline() {
     std::cerr << "Failed to create a bus" << std::endl;
     return false;
   }
-  gst_bus_set_sync_handler(gst_.bus, (GstBusSyncHandler)HandleGstMessage, this,
+  gst_bus_set_sync_handler(gst_.bus, HandleGstMessage, this,
                            NULL);
 
   // Sets properties to fakesink to get the callback of a decoded frame.
@@ -291,8 +291,9 @@ void GstCamera::HandoffHandler(GstElement* fakesink, GstBuffer* buf,
 }
 
 // static
-gboolean GstCamera::HandleGstMessage(GstBus* bus, GstMessage* message,
-                                     gpointer user_data) {
+GstBusSyncReply GstCamera::HandleGstMessage(GstBus* bus,
+                                            GstMessage* message,
+                                            gpointer user_data) {
   switch (GST_MESSAGE_TYPE(message)) {
     case GST_MESSAGE_ELEMENT: {
       auto const* st = gst_message_get_structure(message);
@@ -331,5 +332,8 @@ gboolean GstCamera::HandleGstMessage(GstBus* bus, GstMessage* message,
     default:
       break;
   }
-  return TRUE;
+
+  gst_message_unref(message);
+
+  return GST_BUS_DROP;
 }

--- a/packages/camera/elinux/gst_camera.h
+++ b/packages/camera/elinux/gst_camera.h
@@ -52,7 +52,7 @@ class GstCamera {
 
   static void HandoffHandler(GstElement* fakesink, GstBuffer* buf,
                              GstPad* new_pad, gpointer user_data);
-  static gboolean HandleGstMessage(GstBus* bus, GstMessage* message,
+  static GstBusSyncReply HandleGstMessage(GstBus* bus, GstMessage* message,
                                    gpointer user_data);
 
   bool CreatePipeline();

--- a/packages/video_player/elinux/gst_video_player.cc
+++ b/packages/video_player/elinux/gst_video_player.cc
@@ -403,6 +403,8 @@ void GstVideoPlayer::GetVideoSize(int32_t& width, int32_t& height) {
     return;
   }
 #endif  // USE_EGL_IMAGE_DMABUF
+
+  gst_caps_unref(caps);
 }
 
 // static
@@ -416,6 +418,7 @@ void GstVideoPlayer::HandoffHandler(GstElement* fakesink, GstBuffer* buf,
   int height;
   gst_structure_get_int(structure, "width", &width);
   gst_structure_get_int(structure, "height", &height);
+  gst_caps_unref(caps);
   if (width != self->width_ || height != self->height_) {
     self->width_ = width;
     self->height_ = height;

--- a/packages/video_player/elinux/gst_video_player.cc
+++ b/packages/video_player/elinux/gst_video_player.cc
@@ -472,5 +472,8 @@ GstBusSyncReply GstVideoPlayer::HandleGstMessage(GstBus* bus,
     default:
       break;
   }
-  return GST_BUS_PASS;
+
+  gst_message_unref(message);
+
+  return GST_BUS_DROP;
 }


### PR DESCRIPTION
fix for #92.
If "async queue" is not handled, HandleGstMessage() should return GST_BUS_DROP.