### PR TITLE
[video_player] Dispose all players on hot reload

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Sony Group Corporation
 Hidenori Matsubayashi (hidenori.matsubayashi@gmail.com)
 Makoto Sato (makoto.sato@atmark-techno.com)
 Arjun Patel (patel.arjun50@gmail.com)
+Bari Rao (bari.rao@gmail.com)


### PR DESCRIPTION
On hot-reload, videos will keep playing in background because `dispose()` does not get called on hot-reload.
It is very annoying for the developer. This will result in a better developer experience.

https://github.com/flutter/flutter/issues/10437