### PR TITLE
[video_player] Add initialization step to improve error handling

### DIFF
--- a/packages/video_player/elinux/gst_video_player.h
+++ b/packages/video_player/elinux/gst_video_player.h
@@ -30,6 +30,7 @@ class GstVideoPlayer {
   static void GstLibraryLoad();
   static void GstLibraryUnload();
 
+  bool Init();
   bool Play();
   bool Pause();
   bool Stop();
@@ -64,7 +65,7 @@ class GstVideoPlayer {
   std::string ParseUri(const std::string& uri);
   bool CreatePipeline();
   void DestroyPipeline();
-  void Preroll();
+  bool Preroll();
   void GetVideoSize(int32_t& width, int32_t& height);
 #ifdef USE_EGL_IMAGE_DMABUF
   void UnrefEGLImage();

--- a/packages/video_player/elinux/video_player_elinux_plugin.cc
+++ b/packages/video_player/elinux/video_player_elinux_plugin.cc
@@ -393,9 +393,18 @@ void VideoPlayerPlugin::HandleCreateMethodCall(
 
   flutter::EncodableMap value;
   TextureMessage result;
-  result.SetTextureId(texture_id);
-  value.emplace(flutter::EncodableValue(kEncodableMapkeyResult),
-                result.ToMap());
+
+  bool ok = players_[texture_id]->player->Init();
+  if (ok) {
+    result.SetTextureId(texture_id);
+    value.emplace(flutter::EncodableValue(kEncodableMapkeyResult),
+                  result.ToMap());
+  } else {
+    auto error_message = "Failed to initialize the player with texture id: " +
+                         std::to_string(texture_id);
+    value.emplace(flutter::EncodableValue(kEncodableMapkeyError),
+                  flutter::EncodableValue(WrapError(error_message)));
+  }
   reply(flutter::EncodableValue(value));
 }
 


### PR DESCRIPTION
During preroll, video playback can fail due to codec errors or other issues. Currently, the `VideoPlayerController` is not notified of such errors and fails silently.
With this change, the `VideoPlayerController.initialize` promise will be rejected if the video fails to start (i.e., if the preroll fails).