### PR TITLE
Revert "[video_player] Events can directly be sent from a gstreamer callback thread (#101)

### DIFF
--- a/packages/video_player/elinux/gst_video_player.cc
+++ b/packages/video_player/elinux/gst_video_player.cc
@@ -166,6 +166,25 @@ int64_t GstVideoPlayer::GetCurrentPosition() {
     return -1;
   }
 
+  // TODO: We need to handle this code in the proper plase.
+  // The VideoPlayer plugin doesn't have a main loop, so EOS message
+  // received from GStreamer cannot be processed directly in a callback
+  // function. This is because the event channel message of playback complettion
+  // needs to be thrown in the main thread.
+  {
+    std::unique_lock<std::mutex> lock(mutex_event_completed_);
+    if (is_completed_) {
+      is_completed_ = false;
+      lock.unlock();
+
+      if (auto_repeat_) {
+        SetSeek(0);
+      } else {
+        stream_handler_->OnNotifyCompleted();
+      }
+    }
+  }
+
   return position / GST_MSECOND;
 }
 
@@ -449,11 +468,8 @@ GstBusSyncReply GstVideoPlayer::HandleGstMessage(GstBus* bus,
   switch (GST_MESSAGE_TYPE(message)) {
     case GST_MESSAGE_EOS: {
       auto* self = reinterpret_cast<GstVideoPlayer*>(user_data);
-      if (self->auto_repeat_) {
-        self->SetSeek(0);
-      } else {
-        self->stream_handler_->OnNotifyCompleted();
-      }
+      std::lock_guard<std::mutex> lock(self->mutex_event_completed_);
+      self->is_completed_ = true;
       break;
     }
     case GST_MESSAGE_WARNING: {

--- a/packages/video_player/elinux/gst_video_player.h
+++ b/packages/video_player/elinux/gst_video_player.h
@@ -15,6 +15,7 @@
 #endif  // USE_EGL_IMAGE_DMABUF
 
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 
@@ -79,6 +80,8 @@ class GstVideoPlayer {
   double playback_rate_ = 1.0;
   bool mute_ = false;
   bool auto_repeat_ = false;
+  bool is_completed_ = false;
+  std::mutex mutex_event_completed_;
   std::shared_mutex mutex_buffer_;
   std::unique_ptr<VideoPlayerStreamHandler> stream_handler_;
 


### PR DESCRIPTION
This reverts commit 3f6a04967228fe21e6482c3b87802ed13176f83e.